### PR TITLE
Improve wifi reliability after resuming from suspend

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -2,7 +2,6 @@
 case $1 in
   pre)    # unload the modules before going to sleep
     # handle wifi issues
-    systemctl stop NetworkManager.service
     modprobe -r mwifiex_pcie;
     modprobe -r mwifiex;
     modprobe -r cfg80211;
@@ -27,13 +26,9 @@ case $1 in
     #modprobe intel_ipts
 
     # handle wifi issues: complete cycle
-    modprobe -r mwifiex_pcie;
-    modprobe -r mwifiex;
-    modprobe -r cfg80211;
-    # and reload
-    modprobe -i cfg80211;
-    modprobe -i mwifiex;
-    modprobe -i mwifiex_pcie;
+    modprobe cfg80211;
+    modprobe mwifiex;
+    modprobe mwifiex_pcie;
     echo 1 > /sys/bus/pci/rescan
     systemctl restart NetworkManager.service
     ;;


### PR DESCRIPTION
I am submitting this here to make merging easier for jakeday, since 
there were already changes made to the sleep script by you.

Using the old script I regulary had the problem, that after resuming
from suspend (or hibernate) the wifi would just break. The only way
to fix it was to restart network manager, or disable it in the GNOME
network settings.

I am not a 100% sure *why*, but this change greatly improved the wifi
stability after resume. I am running this for like 5 days now and
didn't see the wifi breaking once. I suppose, that `modprobe` vs
`modprobe -i` is what makes the difference.

If I am the only one with this issue, or if it introduces any 
regressions, feel free to disregard it.