### PR TITLE
suspend.patch-4.19: Update NVMe part

### DIFF
--- a/patches/4.19/0002-suspend.patch
+++ b/patches/4.19/0002-suspend.patch
@@ -1,21 +1,20 @@
-From c9eb0882c82e26571e96f3f010b555b66d9c3dc7 Mon Sep 17 00:00:00 2001
+From c6a20eb579cd118678600940712e0bd7a9ec15f4 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
-Date: Wed, 31 Jul 2019 08:39:18 +0900
+Date: Fri, 20 Sep 2019 01:03:29 +0900
 Subject: [PATCH 02/12] suspend
 
-Note:
-NVMe part will be merged into Linux 5.3. Remove the part in this
-patch when it arrives.
 ---
- drivers/nvme/host/core.c | 36 +++++++++++++--
- drivers/nvme/host/nvme.h |  7 +++
- drivers/nvme/host/pci.c  | 96 ++++++++++++++++++++++++++++++++++++++--
- kernel/power/suspend.c   | 11 +++++
- kernel/sysctl.c          |  9 ++++
- 5 files changed, 153 insertions(+), 6 deletions(-)
+ drivers/nvme/host/core.c |  36 ++++++++++++--
+ drivers/nvme/host/nvme.h |   7 +++
+ drivers/nvme/host/pci.c  | 103 +++++++++++++++++++++++++++++++++++++--
+ drivers/pci/pcie/aspm.c  |  20 ++++++++
+ include/linux/pci.h      |   2 +
+ kernel/power/suspend.c   |  11 +++++
+ kernel/sysctl.c          |   9 ++++
+ 7 files changed, 182 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/nvme/host/core.c b/drivers/nvme/host/core.c
-index ae0b01059fc6..d3bcfead964e 100644
+index ae0b01059..d3bcfead9 100644
 --- a/drivers/nvme/host/core.c
 +++ b/drivers/nvme/host/core.c
 @@ -1028,15 +1028,15 @@ static struct nvme_id_ns *nvme_identify_ns(struct nvme_ctrl *ctrl,
@@ -82,7 +81,7 @@ index ae0b01059fc6..d3bcfead964e 100644
   * Initialize a NVMe controller structures.  This needs to be called during
   * earliest initialization so that we have the initialized structured around
 diff --git a/drivers/nvme/host/nvme.h b/drivers/nvme/host/nvme.h
-index 2653e1f4196d..3bcd14a28e32 100644
+index 2653e1f41..3bcd14a28 100644
 --- a/drivers/nvme/host/nvme.h
 +++ b/drivers/nvme/host/nvme.h
 @@ -433,6 +433,7 @@ void nvme_complete_async_event(struct nvme_ctrl *ctrl, __le16 status,
@@ -107,7 +106,7 @@ index 2653e1f4196d..3bcd14a28e32 100644
  void nvme_stop_keep_alive(struct nvme_ctrl *ctrl);
  int nvme_reset_ctrl(struct nvme_ctrl *ctrl);
 diff --git a/drivers/nvme/host/pci.c b/drivers/nvme/host/pci.c
-index a64a8bca0d5b..5fca9fc04a3f 100644
+index a64a8bca0..8ab9abfd6 100644
 --- a/drivers/nvme/host/pci.c
 +++ b/drivers/nvme/host/pci.c
 @@ -26,6 +26,7 @@
@@ -134,7 +133,7 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
  
  	mutex_lock(&dev->shutdown_lock);
  	result = nvme_pci_enable(dev);
-@@ -2606,16 +2609,94 @@ static void nvme_remove(struct pci_dev *pdev)
+@@ -2606,16 +2609,101 @@ static void nvme_remove(struct pci_dev *pdev)
  }
  
  #ifdef CONFIG_PM_SLEEP
@@ -153,7 +152,7 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
 +	struct nvme_dev *ndev = pci_get_drvdata(to_pci_dev(dev));
 +	struct nvme_ctrl *ctrl = &ndev->ctrl;
 +
-+	if (pm_resume_via_firmware() || !ctrl->npss ||
++	if (ndev->last_ps == U32_MAX ||
 +	    nvme_set_power_state(ctrl, ndev->last_ps) != 0)
 +		nvme_reset_ctrl(ctrl);
 +	return 0;
@@ -166,6 +165,8 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
 +	struct nvme_ctrl *ctrl = &ndev->ctrl;
 +	int ret = -EBUSY;
 +
++	ndev->last_ps = U32_MAX;
++
 +	/*
 +	 * The platform does not remove power for a kernel managed suspend so
 +	 * use host managed nvme power settings for lowest idle power if
@@ -173,8 +174,14 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
 +	 * shutdown.  But if the firmware is involved after the suspend or the
 +	 * device does not support any non-default power states, shut down the
 +	 * device fully.
++	 *
++	 * If ASPM is not enabled for the device, shut down the device and allow
++	 * the PCI bus layer to put it into D3 in order to take the PCIe link
++	 * down, so as to allow the platform to achieve its minimum low-power
++	 * state (which may not be possible if the link is up).
 +	 */
-+	if (pm_suspend_via_firmware() || !ctrl->npss) {
++	if (pm_suspend_via_firmware() || !ctrl->npss ||
++	    !pcie_aspm_enabled(pdev)) {
 +		nvme_dev_disable(ndev, true);
 +		return 0;
 +	}
@@ -187,7 +194,6 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
 +	    ctrl->state != NVME_CTRL_ADMIN_ONLY)
 +		goto unfreeze;
 +
-+	ndev->last_ps = 0;
 +	ret = nvme_get_power_state(ctrl, &ndev->last_ps);
 +	if (ret < 0)
 +		goto unfreeze;
@@ -230,7 +236,7 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
  {
  	struct pci_dev *pdev = to_pci_dev(dev);
  	struct nvme_dev *ndev = pci_get_drvdata(pdev);
-@@ -2623,9 +2704,16 @@ static int nvme_resume(struct device *dev)
+@@ -2623,9 +2711,16 @@ static int nvme_resume(struct device *dev)
  	nvme_reset_ctrl(&ndev->ctrl);
  	return 0;
  }
@@ -249,7 +255,7 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
  
  static pci_ers_result_t nvme_error_detected(struct pci_dev *pdev,
  						pci_channel_state_t state)
-@@ -2728,9 +2816,11 @@ static struct pci_driver nvme_driver = {
+@@ -2728,9 +2823,11 @@ static struct pci_driver nvme_driver = {
  	.probe		= nvme_probe,
  	.remove		= nvme_remove,
  	.shutdown	= nvme_shutdown,
@@ -261,8 +267,54 @@ index a64a8bca0d5b..5fca9fc04a3f 100644
  	.sriov_configure = pci_sriov_configure_simple,
  	.err_handler	= &nvme_err_handler,
  };
+diff --git a/drivers/pci/pcie/aspm.c b/drivers/pci/pcie/aspm.c
+index 1117b25fb..5d7d30f72 100644
+--- a/drivers/pci/pcie/aspm.c
++++ b/drivers/pci/pcie/aspm.c
+@@ -1176,6 +1176,26 @@ static int pcie_aspm_get_policy(char *buffer, const struct kernel_param *kp)
+ module_param_call(policy, pcie_aspm_set_policy, pcie_aspm_get_policy,
+ 	NULL, 0644);
+ 
++/**
++ * pcie_aspm_enabled - Check if PCIe ASPM has been enabled for a device.
++ * @pdev: Target device.
++ */
++bool pcie_aspm_enabled(struct pci_dev *pdev)
++{
++	struct pci_dev *bridge = pci_upstream_bridge(pdev);
++	bool ret;
++
++	if (!bridge)
++		return false;
++
++	mutex_lock(&aspm_lock);
++	ret = bridge->link_state ? !!bridge->link_state->aspm_enabled : false;
++	mutex_unlock(&aspm_lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(pcie_aspm_enabled);
++
+ #ifdef CONFIG_PCIEASPM_DEBUG
+ static ssize_t link_state_show(struct device *dev,
+ 		struct device_attribute *attr,
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index b1f297f4b..94ab2fc80 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -1486,8 +1486,10 @@ extern bool pcie_ports_native;
+ 
+ #ifdef CONFIG_PCIEASPM
+ bool pcie_aspm_support_enabled(void);
++bool pcie_aspm_enabled(struct pci_dev *pdev);
+ #else
+ static inline bool pcie_aspm_support_enabled(void) { return false; }
++static inline bool pcie_aspm_enabled(struct pci_dev *pdev) { return false; }
+ #endif
+ 
+ #ifdef CONFIG_PCIEAER
 diff --git a/kernel/power/suspend.c b/kernel/power/suspend.c
-index 0bd595a0b610..a8385e8894a5 100644
+index 0bd595a0b..a8385e889 100644
 --- a/kernel/power/suspend.c
 +++ b/kernel/power/suspend.c
 @@ -526,6 +526,8 @@ int suspend_devices_and_enter(suspend_state_t state)
@@ -291,7 +343,7 @@ index 0bd595a0b610..a8385e8894a5 100644
  	pm_notifier_call_chain(PM_POST_SUSPEND);
  	pm_restore_console();
 diff --git a/kernel/sysctl.c b/kernel/sysctl.c
-index f8576509c7be..a5fa80e72aba 100644
+index f8576509c..a5fa80e72 100644
 --- a/kernel/sysctl.c
 +++ b/kernel/sysctl.c
 @@ -313,7 +313,16 @@ static int min_extfrag_threshold;


### PR DESCRIPTION
Hello, qzed.

This PR will update suspend.patch for 4.19

Added these two patches on current suspend.patch:
- torvalds/linux@4eaefe8c621c6195c91044396ed8060c179f7aae
  (nvme-pci: Allow PCI bus-level PM to be used if ASPM is disabled)
- torvalds/linux@accd2dd72c8f087441d725dd916688171519e4e6
  (PCI/ASPM: Add pcie_aspm_enabled())

Tested and confirmed that suspend is still working on Surface Book 1 with
THNSN5512GPU7 TOSHIBA NVMe SSD which has issue resuming from suspend
with PCI bus-level PM.