### PR TITLE
Disable bluetooth when suspending without anything connected.

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -1,6 +1,12 @@
 #!/bin/bash
 case $1 in
   pre)    # unload the modules before going to sleep
+
+    # Disable bluetooth if no device is connected
+    if ! bluetoothctl info; then
+      bluetoothctl power off
+    fi
+
     # handle wifi issues
     modprobe -r mwifiex_pcie;
     modprobe -r mwifiex;
@@ -24,6 +30,9 @@ case $1 in
     #modprobe mei_me
     #modprobe mei_hdcp
     #modprobe intel_ipts
+
+    # Restart bluetooth
+    bluetoothctl power on
 
     # handle wifi issues: complete cycle
     modprobe cfg80211;


### PR DESCRIPTION
On Surface Book 2, it is not possible to archive stable S0ix while bluetooth is enabled, but no device is connected. Either S0ix fails completely, or the residency is pretty bad. When bluetooth is disabled, or a device (like the pen) is connected to it, S0ix works file and residency is great.

By disabling bluetooth when no device is connected before suspending, we get working S0ix in all situations. And since no device is connected, the reset won't really matter.

Note: There is the case where you disabled bluetooth through the DE before suspending. While the code might look like it would always reenable bluetooth in that case, that doesn't happen. The DE disables bluetooth but doesn't power down the adapter, making `bluetoothctl power on` a NOP.