### PR TITLE
Remove hard systemd dependency from the sleep script

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -39,7 +39,11 @@ case $1 in
     modprobe mwifiex;
     modprobe mwifiex_pcie;
     echo 1 > /sys/bus/pci/rescan
-    systemctl restart NetworkManager.service
+
+    if [ -x "$(command -v nmcli)" ]  && [ "$(nmcli net)" = "enabled" ]; then
+      nmcli net off
+      nmcli net on
+    fi
     ;;
 esac
 


### PR DESCRIPTION
As discussed with @phunyguy on gitter

This removes the hard systemd dependency from the sleep script, by using `nmcli` directly, which is an upstream tool. This makes it possible to use the script on distributions like gentoo or void, by running it manually or hooking it up to the service manager that is used.

This also removes the forced restart if people willingly disabled NetworkManager.