### PR TITLE
sleep-script: Prevent bluetoothctl from timing out

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -3,7 +3,7 @@ case $1 in
   pre)    # unload the modules before going to sleep
 
     # Disable bluetooth if no device is connected
-    if ! bluetoothctl info; then
+    if ps cax | grep bluetoothd && ! bluetoothctl info; then
       bluetoothctl power off
     fi
 
@@ -32,7 +32,9 @@ case $1 in
     #modprobe intel_ipts
 
     # Restart bluetooth
-    bluetoothctl power on
+    if ps cax | grep bluetoothd; then
+      bluetoothctl power on
+    fi
 
     # handle wifi issues: complete cycle
     modprobe cfg80211;


### PR DESCRIPTION
If bluetooth is disabled in the BIOS, the `bluetoothd` process won't be running. However, `bluetoothctl` waits for that process to launch, which means it timeouts indefinitly, breaking suspend entirely.

By checking if `bluetoothd` is running before calling `bluetoothctl` suspend works fine even if bluetooth is disabled in the BIOS.