### PR TITLE
Replace the HID patch with a better one that fixes all PTP touchpads.

### DIFF
--- a/patches/5.3/0004-hid.patch
+++ b/patches/5.3/0004-hid.patch
@@ -1,151 +1,62 @@
-From 1341a85abda5b8b534818da51ec9d63e0dd3502c Mon Sep 17 00:00:00 2001
-From: qzed <qzed@users.noreply.github.com>
-Date: Tue, 17 Sep 2019 17:16:23 +0200
-Subject: [PATCH 04/10] hid
+From a126114f7a6e01b23e6888631b3942eacca52026 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bla=C5=BE=20Hrastnik?= <blaz@mxxn.io>
+Date: Wed, 6 Nov 2019 19:43:26 +0900
+Subject: [PATCH] HID: Improve Windows Precision Touchpad detection.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
+Per Microsoft spec, usage 0xC5 (page 0xFF) returns a blob containing
+data used to verify the touchpad as a Windows Precision Touchpad.
+
+   0x85, REPORTID_PTPHQA,    //    REPORT_ID (PTPHQA)
+    0x09, 0xC5,              //    USAGE (Vendor Usage 0xC5)
+    0x15, 0x00,              //    LOGICAL_MINIMUM (0)
+    0x26, 0xff, 0x00,        //    LOGICAL_MAXIMUM (0xff)
+    0x75, 0x08,              //    REPORT_SIZE (8)
+    0x96, 0x00, 0x01,        //    REPORT_COUNT (0x100 (256))
+    0xb1, 0x02,              //    FEATURE (Data,Var,Abs)
+
+However, some devices, namely Microsoft's Surface line of products
+instead implement a "segmented device certification report" (usage 0xC6)
+which returns the same report, but in smaller chunks.
+
+    0x06, 0x00, 0xff,        //     USAGE_PAGE (Vendor Defined)
+    0x85, REPORTID_PTPHQA,   //     REPORT_ID (PTPHQA)
+    0x09, 0xC6,              //     USAGE (Vendor usage for segment #)
+    0x25, 0x08,              //     LOGICAL_MAXIMUM (8)
+    0x75, 0x08,              //     REPORT_SIZE (8)
+    0x95, 0x01,              //     REPORT_COUNT (1)
+    0xb1, 0x02,              //     FEATURE (Data,Var,Abs)
+    0x09, 0xC7,              //     USAGE (Vendor Usage)
+    0x26, 0xff, 0x00,        //     LOGICAL_MAXIMUM (0xff)
+    0x95, 0x20,              //     REPORT_COUNT (32)
+    0xb1, 0x02,              //     FEATURE (Data,Var,Abs)
+
+By expanding Win8 touchpad detection to also look for the segmented
+report, all Surface touchpads are now properly recognized by
+hid-multitouch.
+
+Signed-off-by: Blaž Hrastnik <blaz@mxxn.io>
 ---
- drivers/hid/hid-ids.h        | 21 +++++++++----
- drivers/hid/hid-microsoft.c  |  3 +-
- drivers/hid/hid-multitouch.c | 57 ++++++++++++++++++++++++++++++++++++
- drivers/hid/hid-quirks.c     | 11 +++++++
- 4 files changed, 86 insertions(+), 6 deletions(-)
+ drivers/hid/hid-core.c | 4 ++++
+ 1 file changed, 4 insertions(+)
 
-diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index e4d51ce20a6a..62d7f3d5e1fa 100644
---- a/drivers/hid/hid-ids.h
-+++ b/drivers/hid/hid-ids.h
-@@ -824,11 +824,22 @@
- #define USB_DEVICE_ID_MS_DIGITAL_MEDIA_3KV1 0x0732
- #define USB_DEVICE_ID_MS_DIGITAL_MEDIA_600  0x0750
- #define USB_DEVICE_ID_MS_COMFORT_MOUSE_4500	0x076c
--#define USB_DEVICE_ID_MS_COMFORT_KEYBOARD 0x00e3
--#define USB_DEVICE_ID_MS_SURFACE_PRO_2   0x0799
--#define USB_DEVICE_ID_MS_TOUCH_COVER_2   0x07a7
--#define USB_DEVICE_ID_MS_TYPE_COVER_2    0x07a9
--#define USB_DEVICE_ID_MS_POWER_COVER     0x07da
-+#define USB_DEVICE_ID_MS_COMFORT_KEYBOARD	0x00e3
-+#define USB_DEVICE_ID_MS_SURFACE_PRO_2		0x0799
-+#define USB_DEVICE_ID_MS_TOUCH_COVER_2		0x07a7
-+#define USB_DEVICE_ID_MS_TYPE_COVER_2		0x07a9
-+#define USB_DEVICE_ID_MS_TYPE_COVER_3		0x07de
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3	0x07dc
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_1	0x07de
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2	0x07e2
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP	0x07dd
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_4	0x07e8
-+#define USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_1	0x07e4
-+#define USB_DEVICE_ID_MS_SURFACE_BOOK		0x07cd
-+#define USB_DEVICE_ID_MS_SURFACE_BOOK_2		0x0922
-+#define USB_DEVICE_ID_MS_SURFACE_GO			0x096f
-+#define USB_DEVICE_ID_MS_SURFACE_VHF		0xf001
-+#define USB_DEVICE_ID_MS_POWER_COVER		0x07da
- #define USB_DEVICE_ID_MS_XBOX_ONE_S_CONTROLLER	0x02fd
- #define USB_DEVICE_ID_MS_PIXART_MOUSE    0x00cb
+diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+index 63fdbf09b044..2af597cd5d65 100644
+--- a/drivers/hid/hid-core.c
++++ b/drivers/hid/hid-core.c
+@@ -742,6 +742,10 @@ static void hid_scan_feature_usage(struct hid_parser *parser, u32 usage)
+ 	if (usage == 0xff0000c5 && parser->global.report_count == 256 &&
+ 	    parser->global.report_size == 8)
+ 		parser->scan_flags |= HID_SCAN_FLAG_MT_WIN_8;
++
++	if (usage == 0xff0000c6 && parser->global.report_count == 1 &&
++	    parser->global.report_size == 8)
++		parser->scan_flags |= HID_SCAN_FLAG_MT_WIN_8;
+ }
  
-diff --git a/drivers/hid/hid-microsoft.c b/drivers/hid/hid-microsoft.c
-index 8b3a922bdad3..0290a16881e5 100644
---- a/drivers/hid/hid-microsoft.c
-+++ b/drivers/hid/hid-microsoft.c
-@@ -438,7 +438,8 @@ static const struct hid_device_id ms_devices[] = {
- 		.driver_data = MS_HIDINPUT },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_COMFORT_KEYBOARD),
- 		.driver_data = MS_ERGONOMY},
--
-+	{ HID_DEVICE(BUS_VIRTUAL, 0, USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_VHF),
-+		.driver_data = MS_HIDINPUT},
- 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_PRESENTER_8K_BT),
- 		.driver_data = MS_PRESENTER },
- 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x091B),
-diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index b603c14d043b..008e6707f467 100644
---- a/drivers/hid/hid-multitouch.c
-+++ b/drivers/hid/hid-multitouch.c
-@@ -1967,6 +1967,63 @@ static const struct hid_device_id mt_devices[] = {
- 		HID_USB_DEVICE(USB_VENDOR_ID_LG,
- 			USB_DEVICE_ID_LG_MELFAS_MT) },
- 
-+	/* Microsoft Touch Cover */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+		USB_DEVICE_ID_MS_TOUCH_COVER_2) },
-+
-+	/* Microsoft Type Cover */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_2) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_3) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_3) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_1) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_4) },
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_1) },
-+
-+	/* Microsoft Surface Book */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+		USB_DEVICE_ID_MS_SURFACE_BOOK) },
-+
-+	/* Microsoft Surface Book 2 */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+		USB_DEVICE_ID_MS_SURFACE_BOOK_2) },
-+
-+	/* Microsoft Surface Go */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+		USB_DEVICE_ID_MS_SURFACE_GO) },
-+
-+	/* Microsoft Surface Laptop */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
-+			USB_VENDOR_ID_MICROSOFT,
-+			USB_DEVICE_ID_MS_SURFACE_VHF) },
-+
-+	/* Microsoft Power Cover */
-+	{ .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
-+		MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
-+		USB_DEVICE_ID_MS_POWER_COVER) },
-+
- 	/* MosArt panels */
- 	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
- 		MT_USB_DEVICE(USB_VENDOR_ID_ASUS,
-diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index c50bcd967d99..64379a0e4ae1 100644
---- a/drivers/hid/hid-quirks.c
-+++ b/drivers/hid/hid-quirks.c
-@@ -114,6 +114,17 @@ static const struct hid_device_id hid_quirks[] = {
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_PRO_2), HID_QUIRK_NO_INIT_REPORTS },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TOUCH_COVER_2), HID_QUIRK_NO_INIT_REPORTS },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_2), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_1), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_2), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_3_JP), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_PRO_4_1), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_BOOK), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_BOOK_2), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_GO), HID_QUIRK_NO_INIT_REPORTS },
-+	{ HID_DEVICE(BUS_VIRTUAL, 0, USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_SURFACE_VHF), HID_QUIRK_ALWAYS_POLL },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MOJO, USB_DEVICE_ID_RETRO_ADAPTER), HID_QUIRK_MULTI_INPUT },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MSI, USB_DEVICE_ID_MSI_GT683R_LED_PANEL), HID_QUIRK_NO_INIT_REPORTS },
- 	{ HID_USB_DEVICE(USB_VENDOR_ID_MULTIPLE_1781, USB_DEVICE_ID_RAPHNET_4NES4SNES_OLD), HID_QUIRK_MULTI_INPUT },
+ static void hid_scan_collection(struct hid_parser *parser, unsigned type)
 -- 
 2.23.0
 


### PR DESCRIPTION
With this patch, all Surface touchpads are properly detected without any
overrides required. HID_QUIRK_NO_INIT_REPORTS is also not needed because
that's the default for hid-multitouch.

To be removed once accepted upstream: https://patchwork.kernel.org/patch/11230017/