### PR TITLE
Fixed udev rules for type cover

### DIFF
--- a/root/etc/udev/rules.d/98-keyboardscovers.rules
+++ b/root/etc/udev/rules.d/98-keyboardscovers.rules
@@ -1,8 +1,8 @@
 # Type Cover Re-attach (SP4)
-ACTION=="add", SUBSYSTEMS=="usb", ATTR{iProduct}=="Surface Type Cover", RUN+="/bin/sleep 5 && /sbin/modprobe -r i2c_hid && /sbin/modprobe i2c_hid"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{product}=="Surface Type Cover", RUN+="/sbin/modprobe -r i2c_hid && /sbin/modprobe i2c_hid"
 
 # Keyboard Dock (SB2)
-ACTION=="add", SUBSYSTEMS=="usb", ATTR{idVendor}=="045e", ATTR{idProduct}=="0922", RUN+="/sbin/modprobe nouveau"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0922", RUN+="/sbin/modprobe nouveau"
 
 #Keyboard Undock (SB2)
-ACTION=="remove", SUBSYSTEMS=="usb", ENV{ID_MODEL}=="Surface_Keyboard", RUN+="/sbin/modprobe -r nouveau"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{ID_MODEL}=="Surface_Keyboard", RUN+="/sbin/modprobe -r nouveau"


### PR DESCRIPTION
These are adjustments needed in order for the type cover to work properly:

ATTR -> ATTRS

SUBSYSTEMS -> SUBSYSTEM

{iProduct} -> {product}

The initial sleep command was causing things to not work, so this was removed as well.