### PR TITLE
sleep-script: IPTS: fix module unloading on newer kernels

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -14,6 +14,7 @@ case $1 in
 
     ## IPTS: see notes below
     ## > Remove IPTS from ME side
+    #modprobe -r ipts_surface
     #modprobe -r intel_ipts
     #modprobe -r mei_hdcp
     #modprobe -r mei_me
@@ -30,6 +31,7 @@ case $1 in
     #modprobe mei_me
     #modprobe mei_hdcp
     #modprobe intel_ipts
+    #modprobe ipts_surface
 
     # Restart bluetooth
     if ps cax | grep bluetoothd; then


### PR DESCRIPTION
I've been aware of this thing but I've forgotten to do because I personally don't unload IPTS
modules anymore :)

I hope there is a way to resolve module dependency automatically…

On a recent version of kernels, "intel_ipts" module will be used by companion
driver "ipts_surface". So, unload the module first on unloading whole IPTS
modules and load the module last on loading whole IPTS modules.
Otherwise, unloading "intel_ipts" will fail.

Unloading the module will automatically unload "intel_ipts" module but
I did not remove the line for clarity and for kernels that don't have
the companion driver ("ipts_surface").

On my 5.3 kernel:
$ lsmod | grep -e "Used by" -e "ipts"
Module                  Size  Used by
ipts_surface           16384  0
intel_ipts             45056  1 ipts_surface
hid                   143360  6 i2c_hid,usbhid,hid_multitouch,hid_sensor_hub,intel_ipts,hid_generic
mei                   122880  5 mei_hdcp,intel_ipts,mei_me
i915                 2273280  18 intel_ipts

Tested on kernel 5.3.12 and 4.19.85 that use the "ipts_surface" companion driver with IPTS lines
uncommented on sleep script.